### PR TITLE
Fix broken module imports and graph node wiring

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,19 +1,9 @@
+import os
+from src.app import demo
 
-#from langchain_core import 
-from langchain_core.pydantic_v1 import BaseModel, Field
+def main() -> None:
+    """Launch the Gradio demo server."""
+    demo.launch(server_name="0.0.0.0", server_port=int(os.getenv("PORT", 7860)))
 
-from langgraph.graph import Graph
-from typing import Dict, Any, TypedDict
-
-from job.test1.test1 import app
-
-
-
-from .src.llm import get_llm
-
-
-
-def main():
-    pass
-
-    
+if __name__ == "__main__":
+    main()

--- a/src/agents/database.py
+++ b/src/agents/database.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from typing import Any, Dict, List, Optional, Tuple
 
-from langchain_core.pydantic_v1 import BaseModel, Field
+from pydantic import BaseModel, Field
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine, Result
 from sqlalchemy.exc import SQLAlchemyError

--- a/src/agents/database.py
+++ b/src/agents/database.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -5,7 +7,6 @@ from langchain_core.pydantic_v1 import BaseModel, Field
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine, Result
 from sqlalchemy.exc import SQLAlchemyError
-from __future__ import annotations
 
 
 

--- a/src/agents/db_duckdb_agent.py
+++ b/src/agents/db_duckdb_agent.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Any, Dict, List
 import os
 import duckdb
-from langchain_core.pydantic_v1 import BaseModel, Field
+from pydantic import BaseModel, Field
 
 DUCK_PATH = os.getenv("DUCKDB_PATH", "data/db.duckdb")
 

--- a/src/agents/interpreter.py
+++ b/src/agents/interpreter.py
@@ -1,7 +1,7 @@
 from typing import List, Literal, Annotated, Optional, Any, Dict
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import StrOutputParser, PydanticOutputParser
-from langchain_core.pydantic_v1 import BaseModel, Field,ValidationError
+from pydantic import BaseModel, Field, ValidationError
 from src.llm.llm_config import get_llm
 
 TASK_HINT = "One of: lookup, compare, map, trend, image_gallery, report, write, other"
@@ -64,8 +64,8 @@ def interpret(state: Any) -> InterpreterOutputMessages:
     try:
         result: InterpreterOutputMessages= chain.invoke({"user_input": user_input})
 
-    except ValidationError as e:
-        result=InterpreterOutputMessages(
+    except ValidationError:
+        result = InterpreterOutputMessages(
             user_input=user_input,
             intent="lookup",
             entities=[],
@@ -76,8 +76,10 @@ def interpret(state: Any) -> InterpreterOutputMessages:
                         "return a concise summary with citations"
                         ]
         )
-    except ValidationError as e:
-        raise RuntimeError(f"Interpretation failed: {type(e).__name__ : }: {e}")
+    except Exception as e:
+        raise RuntimeError(
+            f"Interpretation failed: {type(e).__name__}: {e}"
+        ) from e
     return result
 
 def interpret_node(state: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/agents/interpreter.py
+++ b/src/agents/interpreter.py
@@ -80,8 +80,12 @@ def interpret(state: Any) -> InterpreterOutputMessages:
         raise RuntimeError(f"Interpretation failed: {type(e).__name__ : }: {e}")
     return result
 
-# def interpret_node(state: Dict[str, Any])-> Dict[str, Any]:
-#     out=interpret(state)
-#     new_state=dict(state)
-#     new_state.update(out.dict())
-#     return new_state
+def interpret_node(state: Dict[str, Any]) -> Dict[str, Any]:
+    """LangGraph node wrapper for :func:`interpret`.
+
+    Takes an arbitrary state, runs :func:`interpret`, and merges the
+    structured output back into the state dictionary."""
+    out = interpret(state)
+    new_state = dict(state)
+    new_state.update(out.dict())
+    return new_state

--- a/src/agents/query_router.py
+++ b/src/agents/query_router.py
@@ -1,7 +1,7 @@
 from typing import List, Literal, Annotated, Optional, Any, Dict
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import StrOutputParser, PydanticOutputParser
-from langchain_core.pydantic_v1 import BaseModel, Field,ValidationError
+from pydantic import BaseModel, Field, ValidationError
 
 TASK_HINT = "One of: lookup, compare, map, trend, image_gallery, report, write, other"
 TOOLS_HINT = "Choose from: DBManager, WebResearcher, Reporter"

--- a/src/graph/build_graph.py
+++ b/src/graph/build_graph.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 from langgraph.graph import StateGraph, END
 from typing import Any, Dict
 
-from interpreter_agent_fixed import interpret_node   # from your canvas file
-from router_agent import route_node                  # from your canvas file
-from db_agent import db_manager_node                 # Postgres path
-from src.agents.db_duckdb_agent import db_manager_duckdb_node  # HF path
+from src.agents.interpreter import interpret_node
+from src.agents.query_router import route_node
+from src.agents.database import db_manager_node
+from src.agents.db_duckdb_agent import db_manager_duckdb_node
 from src.agents.web_researcher import web_researcher_node
 from src.agents.reporter_agent import reporter_node
 
@@ -32,7 +32,7 @@ def build_graph() -> Any:
 
     g.set_entry_point("Interpreter")
     g.add_edge("Interpreter", "QueryRouter")
-    g.add_conditional_edges("QueryRouter", lambda s: s.get("next_nodes", []))
+    g.add_conditional_edges("QueryRouter", lambda s: s.get("next_node", []))
     g.add_edge("DBManager", "Reporter")
     g.add_edge("WebResearcher", "Reporter")
     g.add_edge("Reporter", END)

--- a/src/schemas/schema.py
+++ b/src/schemas/schema.py
@@ -2,7 +2,7 @@
 
 from typing import Dict, List, Literal, Optional
 from typing_extensions import TypedDict
-from langchain_core.pydantic_v1 import BaseModel, Field
+from pydantic import BaseModel, Field
 
 """
 SpeciesAssessmentOutput (extends base) (only for extinction/risk agent)


### PR DESCRIPTION
## Summary
- replace placeholder imports with working ones and simplify `main.py`
- wire graph builder to real agent modules and fix conditional edges
- add interpreter node wrapper and correct database module imports

## Testing
- `python -m py_compile main.py src/graph/build_graph.py src/agents/interpreter.py src/agents/database.py`
- `python main.py & sleep 5; pkill -f 'python main.py' >/dev/null 2>&1`

------
https://chatgpt.com/codex/tasks/task_e_68a132de9974832c9ee08233693906d3